### PR TITLE
Modularize bloomd injection

### DIFF
--- a/bloomd.go
+++ b/bloomd.go
@@ -75,8 +75,6 @@ func (r rejecter) Reject(claims map[string]interface{}) bool {
 
 	found, err := r.filter.Multi([]string{hash})
 
-	r.filter.Set(hash)
-
 	if err != nil {
 		r.logger.Error("Bloomd error:", err.Error())
 	}

--- a/bloomd.go
+++ b/bloomd.go
@@ -1,0 +1,121 @@
+package krakend
+
+import (
+	"fmt"
+	"log"
+	"errors"
+	"strings"
+	"encoding/json"
+	"crypto/sha256"
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/logging"
+	"github.com/devopsfaith/krakend-jose"
+	"github.com/geetarista/go-bloomd/bloomd"
+)
+
+const Namespace = "github.com/openrm/bloomd"
+
+const (
+	claimIssuedAt = "iat"
+	claimExpirationTime = "exp"
+)
+
+var hashFields = []string{"id", "organizationId", claimIssuedAt, claimExpirationTime}
+
+// errors
+var (
+	errNoConfig = errors.New("no config for bloomd")
+	errInvalidConfig = errors.New("invalid config for bloomd")
+	errNoFilterName = errors.New("filter name is required")
+	errFieldNotExist = errors.New("token missing required field")
+	errInvalidField = errors.New("token contains invalid field")
+)
+
+// jose.Rejecter implementation
+type rejecter struct {
+	filter *bloomd.Filter
+	logger logging.Logger
+}
+
+func (r rejecter) assertFields(claims map[string]interface{}) ([]string, error) {
+	fields := make([]string, len(hashFields))
+	for i, k := range hashFields {
+		v, ok := claims[k]
+		if !ok {
+			return fields, errFieldNotExist
+		}
+		str, ok := v.(string)
+		if !ok {
+			return fields, errInvalidField
+		}
+		fields[i] = str
+	}
+	return fields, nil
+}
+
+func (r rejecter) calcHash(fields []string) string {
+	id := strings.Join(fields, ".")
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(id)))
+}
+
+func (r rejecter) Reject(claims map[string]interface{}) bool {
+	if r.filter == nil || r.filter.Conn == nil {
+		return true
+	}
+	fields, err := r.assertFields(claims)
+	if err != nil {
+		return false
+	}
+	hash := r.calcHash(fields)
+	found, err := r.filter.Multi([]string{hash})
+	if err != nil {
+		r.logger.Error("Bloomd error:", err.Error())
+	}
+	if len(found) > 0 && found[0] {
+		return false
+	}
+	return true
+}
+
+type nopRejecter struct {}
+func (nr nopRejecter) Reject(map[string]interface{}) bool { return true }
+
+
+// config map
+type bloomdConfig struct {
+	Name string `json:"name"`
+	Address string `json:"server_addr"`
+}
+
+
+func createFilter(addr string, filter *bloomd.Filter) error {
+	client := bloomd.NewClient(addr)
+	return client.CreateFilter(filter)
+}
+
+func registerBloomd(scfg config.ServiceConfig, logger logging.Logger) (jose.Rejecter, error) {
+	data, ok := scfg.ExtraConfig[Namespace]
+	if !ok {
+		logger.Debug(errNoConfig.Error())
+		return nopRejecter{}, errNoConfig
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		logger.Debug(errInvalidConfig.Error())
+		return nopRejecter{}, errInvalidConfig
+	}
+	var cfg bloomdConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		logger.Debug(err.Error(), string(raw))
+		return nopRejecter{}, errInvalidConfig
+	}
+	if cfg.Name == "" {
+		return nopRejecter{}, errNoFilterName
+	}
+	filter := &bloomd.Filter{ Name: cfg.Name }
+	if err := createFilter(cfg.Address, filter); err != nil {
+		log.Fatalf("Bloomd filter creation failed (%s):", cfg.Address, err.Error())
+	}
+	logger.Info("BLOOMD: connected")
+	return rejecter{filter, logger}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/devopsfaith/krakend-gologging v0.0.0-20190131142345-f3f256584ecc
 	github.com/devopsfaith/krakend-httpcache v0.0.0-20181030153148-8474476ff874
 	github.com/devopsfaith/krakend-httpsecure v0.0.0-20180922151646-cce73b27c717
+	github.com/devopsfaith/krakend-jose v0.0.0-20190226224132-34c0555a9893
 	github.com/devopsfaith/krakend-jsonschema v0.0.0-20190124184701-5705a5015d7a
 	github.com/devopsfaith/krakend-logstash v0.0.0-20190131142205-17f4745d3502
 	github.com/devopsfaith/krakend-martian v0.0.0-20190424133031-29314a524a91
@@ -56,7 +57,7 @@ require (
 	github.com/devopsfaith/krakend-xml v0.0.0-20180408220837-5ce94062a4cc
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/geetarista/go-bloomd v0.0.0-20140722181834-7f8e8a358bec // indirect
+	github.com/geetarista/go-bloomd v0.0.0-20140722181834-7f8e8a358bec
 	github.com/gin-contrib/sse v0.0.0-20190125020943-a7658810eb74
 	github.com/gin-gonic/gin v1.3.0
 	github.com/go-contrib/uuid v1.2.0
@@ -95,7 +96,6 @@ require (
 	github.com/nats-io/nkeys v0.0.2
 	github.com/nats-io/nuid v1.0.1
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-	github.com/openrm/krakend-jose v0.0.0-20190822020746-e9fcc8b242cb
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin/zipkin-go v0.1.6
 	github.com/pelletier/go-toml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/devopsfaith/krakend-httpcache v0.0.0-20181030153148-8474476ff874 h1:D
 github.com/devopsfaith/krakend-httpcache v0.0.0-20181030153148-8474476ff874/go.mod h1:cNBLieKKu6+0aLd3bwOGg5dGGqkK2U+zEIbmYot1nhI=
 github.com/devopsfaith/krakend-httpsecure v0.0.0-20180922151646-cce73b27c717 h1:MZYGaXMcCxoGrOs2kWZxj0BGVCfm1gRtlfJiKo3sJX4=
 github.com/devopsfaith/krakend-httpsecure v0.0.0-20180922151646-cce73b27c717/go.mod h1:H2qRuYv4A56Kw/cynhiFBP9nFNFhHwj70DEU0CSldbI=
+github.com/devopsfaith/krakend-jose v0.0.0-20190226224132-34c0555a9893 h1:VJoz07Cj6YyZq+fweyTWA9MaUUHU2202YWLqp8ek7ec=
+github.com/devopsfaith/krakend-jose v0.0.0-20190226224132-34c0555a9893/go.mod h1:RQO17T5c8HIMmR6kBkuSy4NatZQb02KENHkBSAqI5Ok=
 github.com/devopsfaith/krakend-jsonschema v0.0.0-20190124184701-5705a5015d7a h1:VEl62LlUIqkPb0WcUvzzBr/2hu8+uMaHypBK3FqkyI0=
 github.com/devopsfaith/krakend-jsonschema v0.0.0-20190124184701-5705a5015d7a/go.mod h1:PYIFUHqJMhgZwxunzrdwZ8N0OFpnneH0uC55f7wq7GM=
 github.com/devopsfaith/krakend-logstash v0.0.0-20190131142205-17f4745d3502 h1:dp2Q9DlR/qcN8sESUk4etOQ3sFBkW1+YXVw0+GWSPpc=
@@ -472,6 +474,7 @@ github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nr
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v0.0.0-20180523094522-3864e76763d9/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=

--- a/handler_factory.go
+++ b/handler_factory.go
@@ -1,8 +1,8 @@
 package krakend
 
 import (
-	"github.com/openrm/krakend-jose"
-	ginjose "github.com/openrm/krakend-jose/gin"
+	"github.com/devopsfaith/krakend-jose"
+	ginjose "github.com/devopsfaith/krakend-jose/gin"
 	metrics "github.com/devopsfaith/krakend-metrics/gin"
 	opencensus "github.com/devopsfaith/krakend-opencensus/router/gin"
 	juju "github.com/devopsfaith/krakend-ratelimit/juju/router/gin"

--- a/tests/fixtures/krakend.json
+++ b/tests/fixtures/krakend.json
@@ -132,7 +132,7 @@
                         "check_expr": "size(JWT.roles)>1"
                     }
                 ],
-                "github.com/openrm/krakend-jose/validator": {
+                "github.com/devopsfaith/krakend-jose/validator": {
                     "alg": "HS256",
                     "audience": ["http://api.example.com"],
                     "roles_key": "roles",
@@ -392,7 +392,7 @@
                         }
                     }
                 },
-                "github.com/openrm/krakend-jose/validator": {
+                "github.com/devopsfaith/krakend-jose/validator": {
                     "alg": "HS256",
                     "audience": ["http://api.example.com"],
                     "roles_key": "roles",
@@ -428,7 +428,7 @@
                         }
                     }
                 },
-                "github.com/openrm/krakend-jose/signer": {
+                "github.com/devopsfaith/krakend-jose/signer": {
                     "alg": "HS256",
                     "kid": "sim2",
                     "keys-to-sign": ["access_token"],


### PR DESCRIPTION
Thanks a lot for the bloomd integration. I wrote a pluggable module to make things simple.
This way:
 - we don't touch krakend-jose, so only need to maintain this repository
 - we only have to add an extra config at the root level, not each endpoint
 - even if we add another rejecter, we won't call the server multiple times
 - (we can reject tokens before it validates with jwk)

Example:
```
       "extra_config": {
          ...,
          "github.com/openrm/bloomd": {
            "name": "token_rejecter",
            "server_addr": "localhost:8673"
          },
          ...
        }
```